### PR TITLE
New alias for influx group by several tags

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -63,6 +63,15 @@ function (_, TableModel) {
       var group = g1 || g2;
       var segIndex = parseInt(group, 10);
 
+      if(group==="t") {
+        var r='';
+        for(var k in series.tags) { 
+          if (series.tags.hasOwnProperty(k)) { 
+            r+=k+': '+series.tags[k]+', ';
+          }
+        }
+        return r.slice(0,-2);
+      }
       if (group === 'm' || group === 'measurement') { return series.name; }
       if (group === 'col') { return series.columns[index]; }
       if (!isNaN(segIndex)) { return segments[segIndex]; }


### PR DESCRIPTION
Add alias in case of grouping by several tag in influx. 
The result is : 

> tag1:v1, tag2:v3, tag3:v4 
![image](https://user-images.githubusercontent.com/29224815/27188267-e9fc9d1c-51ed-11e7-9593-8db8ed39946b.png)

instead of : 

> agg.sum {tag1:v1, tag2:v3, tag3:v4 }
![image](https://user-images.githubusercontent.com/29224815/27188285-f8ba3918-51ed-11e7-95d5-6fba39251990.png)

